### PR TITLE
update node quickstart examples to lib-node-databox 0.10.7

### DIFF
--- a/node/app/src/Dockerfile
+++ b/node/app/src/Dockerfile
@@ -9,6 +9,9 @@ RUN addgroup -S databox && adduser -S -g databox databox && \
 
 ADD ./package.json package.json
 
+# only if using git
+RUN apk --no-cache add git
+
 RUN npm install --production
 
 USER databox

--- a/node/app/src/Dockerfile-dev
+++ b/node/app/src/Dockerfile-dev
@@ -6,6 +6,9 @@ RUN addgroup -S databox && adduser -S -g databox databox && \
 apk --no-cache add build-base pkgconfig nodejs npm libzmq zeromq-dev libsodium-dev python  && \
 npm install zeromq@4.6.0 --zmq-external --verbose
 
+# if using git
+RUN apk --no-cache add git
+
 #globally install node packages and add to path
 ADD ./package.json package.json
 RUN npm install -g
@@ -20,4 +23,5 @@ LABEL databox.type="app"
 
 EXPOSE 8080
 
-CMD ["npm","run","start-dev"]
+CMD ["sleep","3000000"]
+#CMD ["npm","run","start-dev"]

--- a/node/app/src/Dockerfile-dev
+++ b/node/app/src/Dockerfile-dev
@@ -23,5 +23,4 @@ LABEL databox.type="app"
 
 EXPOSE 8080
 
-CMD ["sleep","3000000"]
-#CMD ["npm","run","start-dev"]
+CMD ["npm","run","start-dev"]

--- a/node/app/src/main.js
+++ b/node/app/src/main.js
@@ -22,18 +22,16 @@ const listenToActuator = (emitter) => {
     console.log("started listening to actuator");
 
     emitter.on('data', (data) => {
-        console.log("seen data from the hello world actuator!", JSON.parse(data.data));
+        console.log("seen data from the hello world actuator!", data);
         if (ws) {
-            ws.send(data.data);
-            databox.export.longpoll('https://export.amar.io/', data.data)
-                .catch((err) => {
-                    console.log("[error] export.longpoll ", err)
-                })
+	    let json = JSON.stringify(data.data)
+            ws.send(json);
+ 	    // Note, export service deprecated and not currently supported
         }
     });
 
     emitter.on('error', (err) => {
-        console.warn(err);
+        console.warn("error from actuator", err);
     });
 }
 
@@ -48,7 +46,7 @@ if (DATABOX_TESTING) {
     let helloWorldActuator = databox.HypercatToDataSourceMetadata(process.env[`DATASOURCE_helloWorldActuator`]);
     helloWorldActuatorDataSourceID = helloWorldActuator.DataSourceID;
     let helloWorldStore = databox.GetStoreURLFromHypercat(process.env[`DATASOURCE_helloWorldActuator`]);
-    store = databox.NewStoreClient(helloWorldStore, DATABOX_ARBITER_ENDPOINT, true/*debug false*/)
+    store = databox.NewStoreClient(helloWorldStore, DATABOX_ARBITER_ENDPOINT, false)
     store.TSBlob.Observe(helloWorldActuatorDataSourceID, 0)
     .then((emitter) => {
         listenToActuator(emitter);

--- a/node/app/src/package.json
+++ b/node/app/src/package.json
@@ -29,7 +29,7 @@
     "express": "^4.16.3",
     "http": "0.0.0",
     "https": "^1.0.0",
-    "node-databox": "https://github.com/cgreenhalgh/lib-node-databox.git",
+    "node-databox": "^0.10.7",
     "ws": "^6.0.0"
   }
 }

--- a/node/app/src/package.json
+++ b/node/app/src/package.json
@@ -29,7 +29,7 @@
     "express": "^4.16.3",
     "http": "0.0.0",
     "https": "^1.0.0",
-    "node-databox": "0.9.0",
+    "node-databox": "https://github.com/cgreenhalgh/lib-node-databox.git",
     "ws": "^6.0.0"
   }
 }

--- a/node/driver/src/Dockerfile
+++ b/node/driver/src/Dockerfile
@@ -9,6 +9,9 @@ apk del build-base pkgconfig libsodium-dev python zeromq-dev
 
 ADD ./package.json package.json
 
+# only if using git...
+RUN apk --no-cache add git
+
 RUN npm install --production
 
 USER databox

--- a/node/driver/src/databox-manifest.json
+++ b/node/driver/src/databox-manifest.json
@@ -28,7 +28,7 @@
         {
             "data-source-type": "helloWorldActuator",
             "description": "hello world actuator",
-            "store-type": "kv",
+            "store-type": "ts/blob",
             "schema": {}
         }
     ]

--- a/node/driver/src/main.js
+++ b/node/driver/src/main.js
@@ -4,15 +4,12 @@ var express = require("express");
 var bodyParser = require("body-parser");
 var databox = require("node-databox");
 
+const DATABOX_ARBITER_ENDPOINT = process.env.DATABOX_ARBITER_ENDPOINT || 'tcp://127.0.0.1:4444';
 const DATABOX_ZMQ_ENDPOINT = process.env.DATABOX_ZMQ_ENDPOINT || "tcp://127.0.0.1:5555";
 const DATABOX_TESTING = !(process.env.DATABOX_VERSION);
 const PORT = process.env.port || '8080';
 
-//create a timeseries blob client for communicating with the timeseries store
-const tsc = databox.NewTimeSeriesBlobClient(DATABOX_ZMQ_ENDPOINT, false);
-
-//create a keyvalue client for storing config
-const kvc = databox.NewKeyValueClient(DATABOX_ZMQ_ENDPOINT, false);
+const store = databox.NewStoreClient(DATABOX_ZMQ_ENDPOINT, DATABOX_ARBITER_ENDPOINT);
 
 //get the default store metadata
 const metaData = databox.NewDataSourceMetadata();
@@ -36,18 +33,18 @@ const helloWorldActuator = {
     Vendor: 'Databox Inc.',
     DataSourceType: 'helloWorldActuator',
     DataSourceID: 'helloWorldActuator',
-    StoreType: 'ts',
+    StoreType: 'ts/blob',
     IsActuator: true,
 }
 
 ///now create our stores using our clients.
-kvc.RegisterDatasource(helloWorldConfig).then(() => {
+store.RegisterDatasource(helloWorldConfig).then(() => {
     console.log("registered helloWorldConfig");
     //now register the actuator
-    return tsc.RegisterDatasource(helloWorldActuator)
+    return store.RegisterDatasource(helloWorldActuator)
 }).catch((err) => { console.log("error registering helloWorld config datasource", err) }).then(() => {
     console.log("registered helloWorldActuator, observing", helloWorldActuator.DataSourceID);
-    tsc.Observe(helloWorldActuator.DataSourceID, 0)
+    store.TSBlob.Observe(helloWorldActuator.DataSourceID, 0)
         .catch((err) => {
             console.log("[Actuation observing error]", err);
         })
@@ -75,7 +72,7 @@ app.get("/", function (req, res) {
 });
 
 app.get("/ui", function (req, res) {
-    kvc.Read(helloWorldConfig.DataSourceID, "config").then((result) => {
+    store.KV.Read(helloWorldConfig.DataSourceID, "config").then((result) => {
         console.log("result:", helloWorldConfig.DataSourceID, result);
         res.render('index', { config: result.value });
     }).catch((err) => {
@@ -89,7 +86,7 @@ app.post('/ui/setConfig', (req, res) => {
     const config = req.body.config;
 
     return new Promise((resolve, reject) => {
-        kvc.Write(helloWorldConfig.DataSourceID, "config", { key: helloWorldConfig.DataSourceID, value: config }).then(() => {
+        store.KV.Write(helloWorldConfig.DataSourceID, "config", { key: helloWorldConfig.DataSourceID, value: config }).then(() => {
             console.log("successfully written!", config);
             resolve();
         }).catch((err) => {
@@ -111,6 +108,6 @@ if (DATABOX_TESTING) {
     http.createServer(app).listen(PORT);
 } else {
     console.log("[Creating https server]", PORT);
-    const credentials = databox.getHttpsCredentials();
+    const credentials = databox.GetHttpsCredentials();
     https.createServer(credentials, app).listen(PORT);
 }

--- a/node/driver/src/main.js
+++ b/node/driver/src/main.js
@@ -9,7 +9,7 @@ const DATABOX_ZMQ_ENDPOINT = process.env.DATABOX_ZMQ_ENDPOINT || "tcp://127.0.0.
 const DATABOX_TESTING = !(process.env.DATABOX_VERSION);
 const PORT = process.env.port || '8080';
 
-const store = databox.NewStoreClient(DATABOX_ZMQ_ENDPOINT, DATABOX_ARBITER_ENDPOINT);
+const store = databox.NewStoreClient(DATABOX_ZMQ_ENDPOINT, DATABOX_ARBITER_ENDPOINT, false);
 
 //get the default store metadata
 const metaData = databox.NewDataSourceMetadata();

--- a/node/driver/src/package.json
+++ b/node/driver/src/package.json
@@ -29,6 +29,6 @@
     "express": "^4.16.3",
     "http": "0.0.0",
     "https": "^1.0.0",
-    "node-databox": "https://github.com/cgreenhalgh/lib-node-databox.git"
+    "node-databox": "^0.10.7"
   }
 }

--- a/node/driver/src/package.json
+++ b/node/driver/src/package.json
@@ -29,6 +29,6 @@
     "express": "^4.16.3",
     "http": "0.0.0",
     "https": "^1.0.0",
-    "node-databox": "^0.9.0"
+    "node-databox": "https://github.com/cgreenhalgh/lib-node-databox.git"
   }
 }


### PR DESCRIPTION
(see databox/lib-node-databox#46 for required fixes to lib-node-databox and tick to 0.10.7)

Updates quickstart examples to work with 0.10.x lib-node-databox.
Note, export service not supported in that version so removed from app example.